### PR TITLE
Change default port to 443 (HTTPS mimicking)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,8 +8,8 @@
 # AmneziaWG interface name
 AWG_INTERFACE=awg0
 
-# UDP listening port (51820 default, use 443 or 53 to mimic HTTPS/DNS)
-AWG_PORT=51820
+# UDP listening port (443 default to mimic HTTPS, or use 53 for DNS)
+AWG_PORT=443
 
 # VPN internal network
 AWG_NET=10.13.13.0/24

--- a/docker-compose.s2s.yml
+++ b/docker-compose.s2s.yml
@@ -18,7 +18,7 @@ services:
       - /lib/modules:/lib/modules:ro
     environment:
       - AWG_INTERFACE=${AWG_INTERFACE:-awg0}
-      - AWG_PORT=${AWG_PORT:-51820}
+      - AWG_PORT=${AWG_PORT:-443}
       - AWG_NET=${AWG_NET:-10.13.13.0/24}
       - AWG_SERVER_IP=${AWG_SERVER_IP:-10.13.13.1}
       - AWG_DNS=${AWG_DNS:-8.8.8.8,8.8.4.4}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,14 +18,14 @@ services:
     networks:
       - amneziawg-net
     ports:
-      - "${AWG_PORT:-51820}:${AWG_PORT:-51820}/udp"
+      - "${AWG_PORT:-443}:${AWG_PORT:-443}/udp"
     volumes:
       - ./config:/app/config
       - ./clients:/app/clients
       - /lib/modules:/lib/modules:ro
     environment:
       - AWG_INTERFACE=${AWG_INTERFACE:-awg0}
-      - AWG_PORT=${AWG_PORT:-51820}
+      - AWG_PORT=${AWG_PORT:-443}
       - AWG_NET=${AWG_NET:-10.13.13.0/24}
       - AWG_SERVER_IP=${AWG_SERVER_IP:-10.13.13.1}
       - AWG_DNS=${AWG_DNS:-8.8.8.8,8.8.4.4}


### PR DESCRIPTION
## Summary

Changes the default AmneziaWG port from 51820 to 443 across all configuration files. Port 443 is the standard HTTPS port, which aligns with AmneziaWG's core purpose of mimicking HTTPS traffic to bypass Deep Packet Inspection (DPI) systems.

Files changed:
- `.env.example`: Default `AWG_PORT` changed from 51820 to 443
- `docker-compose.yml`: Default port fallback changed to 443
- `docker-compose.s2s.yml`: Default port fallback changed to 443

## Review & Testing Checklist for Human

- [ ] **Port conflict check**: Verify that port 443 is not already in use on your server (common conflict with nginx/apache). Run `ss -tulnp | grep 443` to check.
- [ ] **Privileged port**: Port 443 requires root privileges to bind. Confirm this is acceptable for your deployment environment.
- [ ] **Existing installations**: This only affects new installations. Existing `.env` files will retain their configured port.

**Recommended test plan:**
1. Fresh clone without existing `.env`
2. Run `make init` and verify `.env` has `AWG_PORT=443`
3. Run `make up` and verify container binds to port 443 (`docker ps`)
4. Add a test client and verify the generated config has `Endpoint: <ip>:443`

### Notes

This is a configuration-only change with no functional code modifications. The change reflects that AmneziaWG's primary use case is DPI bypass by mimicking HTTPS traffic.

Link to Devin run: https://app.devin.ai/sessions/dab3c78c87594b0099a1f9a083ba0a99
Requested by: Sychin Andrey (@asychin)