### PR TITLE
Fix client config permissions - make configs readable for users

### DIFF
--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -466,26 +466,26 @@ create_client_config() {
     
     log "Создаем конфигурацию для клиента: $client_name"
     
-    # Убеждаемся что директория clients существует
+    # Убеждаемся что директория clients существует (755 for user access)
     mkdir -p /app/clients
-    chmod 750 /app/clients
+    chmod 755 /app/clients
     
     # Генерируем ключи клиента
     CLIENT_PRIVATE_KEY=$(awg genkey)
     CLIENT_PUBLIC_KEY=$(echo "$CLIENT_PRIVATE_KEY" | awg pubkey)
     
-    # Сохраняем ключи
+    # Сохраняем ключи (private key secure, public key readable)
     echo "$CLIENT_PRIVATE_KEY" > "/app/clients/${client_name}_private.key"
+    chmod 600 "/app/clients/${client_name}_private.key"
     echo "$CLIENT_PUBLIC_KEY" > "/app/clients/${client_name}_public.key"
+    chmod 644 "/app/clients/${client_name}_public.key"
     
     # Создаем конфигурацию клиента
     cat > "/app/clients/${client_name}.conf" << EOF
 [Interface]
 PrivateKey = ${CLIENT_PRIVATE_KEY}
-Address = ${client_ip}/24
+Address = ${client_ip}/32
 DNS = ${AWG_DNS}
-
-# Параметры обфускации AmneziaWG
 Jc = ${AWG_JC}
 Jmin = ${AWG_JMIN}
 Jmax = ${AWG_JMAX}
@@ -502,6 +502,9 @@ Endpoint = ${SERVER_PUBLIC_IP}:${AWG_PORT}
 AllowedIPs = ${ALLOWED_IPS:-0.0.0.0/0}
 PersistentKeepalive = 25
 EOF
+    
+    # Make client config readable for users to import
+    chmod 644 "/app/clients/${client_name}.conf"
     
     # Добавляем peer в конфигурацию сервера
     cat >> "$CONFIG_FILE" << EOF

--- a/scripts/manage-clients.sh
+++ b/scripts/manage-clients.sh
@@ -371,9 +371,14 @@ AllowedIPs = ${ALLOWED_IPS:-0.0.0.0/0}
 PersistentKeepalive = 25
 EOF
     
-    # Сохраняем ключи отдельно
+    # Make client config readable for users to import
+    chmod 644 "${CLIENTS_DIR}/${client_name}.conf"
+    
+    # Сохраняем ключи отдельно (keep private key secure)
     echo "$CLIENT_PRIVATE_KEY" > "${CLIENTS_DIR}/${client_name}_private.key"
+    chmod 600 "${CLIENTS_DIR}/${client_name}_private.key"
     echo "$CLIENT_PUBLIC_KEY" > "${CLIENTS_DIR}/${client_name}_public.key"
+    chmod 644 "${CLIENTS_DIR}/${client_name}_public.key"
     
     # Добавляем peer в конфигурацию сервера
     cat >> "$CONFIG_FILE" << EOF


### PR DESCRIPTION
## Summary

Fixes file permission issue where client configs created inside Docker (as root) were not readable by non-root users on the host system. This prevented users from importing configs into VPN clients.

Changes:
- Client config files (.conf): changed to 644 (readable by all)
- Clients directory: changed from 750 to 755 (accessible by all)
- Private key files: explicitly set to 600 (secure)
- Public key files: explicitly set to 644 (readable)
- Also fixed Address mask from /24 to /32 in entrypoint.sh to match manage-clients.sh

## Review & Testing Checklist for Human

- [ ] **Security review**: Client config files contain the private key and will now be world-readable (644). This is intentional since users need to read/copy these configs, but verify this is acceptable for your use case.
- [ ] **Test new client creation**: Run `make client-add testuser` and verify:
  - `ls -la clients/` shows directory with 755 permissions
  - `ls -la clients/testuser.conf` shows 644 permissions
  - `ls -la clients/testuser_private.key` shows 600 permissions
  - Non-root user can read `clients/testuser.conf`
- [ ] **Verify existing clients**: If you have existing clients, their permissions won't change automatically. You may need to manually `chmod 644 clients/*.conf` for existing configs.

**Recommended test plan:**
1. Stop VPN: `make down`
2. Remove existing test client if any
3. Start VPN: `make up`
4. Create new client: `make client-add testuser`
5. As non-root user, verify you can read: `cat clients/testuser.conf`
6. Import config into AmneziaVPN client and verify connection works

### Notes

The /24 to /32 Address mask change in entrypoint.sh aligns it with the fix already applied to manage-clients.sh in commit 2fe1ddb.

Link to Devin run: https://app.devin.ai/sessions/dab3c78c87594b0099a1f9a083ba0a99
Requested by: Sychin Andrey (@asychin)