### PR TITLE
Fix MTU and add MSS clamping to prevent connection drops in S2S mode

### DIFF
--- a/scripts/manage-clients.sh
+++ b/scripts/manage-clients.sh
@@ -354,6 +354,7 @@ add_client() {
 PrivateKey = ${CLIENT_PRIVATE_KEY}
 Address = ${client_ip}/32
 DNS = ${AWG_DNS:-8.8.8.8,8.8.4.4}
+MTU = 1280
 Jc = ${AWG_JC}
 Jmin = ${AWG_JMIN}
 Jmax = ${AWG_JMAX}


### PR DESCRIPTION
## Summary

Fixes connection drops that occur after ~5-6 pings when using site-to-site (S2S) mode with `network_mode: host`. The root cause is PMTUD Black Hole - in host network mode, Docker's automatic MSS clamping is not available, causing large packets to be silently dropped when ICMP is blocked somewhere in the path.

Changes:
- Add MSS clamping iptables rule (`--clamp-mss-to-pmtu`) for TCP connections
- Set MTU to 1280 on the awg0 interface (safe value that works everywhere)
- Add `MTU = 1280` to generated client configs
- Fix Address mask from `/24` to `/32` in entrypoint.sh client config (consistency with manage-clients.sh)

## Review & Testing Checklist for Human

- [ ] **Test S2S mode stability**: After applying this fix, verify that connections no longer drop after a few pings. Run `ping` to a host on the server's local network for at least 2-3 minutes.
- [ ] **Verify MTU value**: 1280 is conservative. If you need better throughput, consider testing with 1380 or 1420 instead.
- [ ] **Regenerate existing clients**: Existing client configs won't have the MTU setting. Either regenerate them or manually add `MTU = 1280` to the `[Interface]` section.

**Recommended test plan:**
1. Merge PR #11 first (permissions fix)
2. Merge this PR
3. Run `make down && make up-s2s`
4. Regenerate a test client: `make client-rm testuser && make client-add testuser`
5. Connect with AmneziaVPN client
6. Run continuous ping to a local network host for 2+ minutes
7. Verify connection remains stable

### Notes

The MSS clamping rule is applied globally to FORWARD traffic. This is standard practice for VPN servers and should not cause issues.

Link to Devin run: https://app.devin.ai/sessions/dab3c78c87594b0099a1f9a083ba0a99
Requested by: Sychin Andrey (@asychin)