### PR TITLE
Add native S2S mode to avoid Docker iptables conflicts

### DIFF
--- a/scripts/install-s2s.sh
+++ b/scripts/install-s2s.sh
@@ -1,0 +1,345 @@
+#!/bin/bash
+# Native S2S Installation Script for AmneziaWG
+# Installs AmneziaWG directly on the host system (without Docker)
+# This avoids Docker iptables conflicts that cause connection drops in S2S mode
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+
+# Check root
+if [ "$EUID" -ne 0 ]; then
+    error "This script must be run as root"
+    exit 1
+fi
+
+# Get script directory (where the project is located)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+log "Project directory: $PROJECT_DIR"
+
+# Load .env file
+if [ -f "$PROJECT_DIR/.env" ]; then
+    log "Loading configuration from .env..."
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+else
+    error ".env file not found. Run 'make init-s2s' first."
+    exit 1
+fi
+
+# Configuration from .env
+AWG_INTERFACE=${AWG_INTERFACE:-awg0}
+AWG_PORT=${AWG_PORT:-51820}
+AWG_NET=${AWG_NET:-10.13.13.0/24}
+AWG_SERVER_IP=${AWG_SERVER_IP:-10.13.13.1}
+AWG_DNS=${AWG_DNS:-8.8.8.8,8.8.4.4}
+AWG_JC=${AWG_JC:-7}
+AWG_JMIN=${AWG_JMIN:-50}
+AWG_JMAX=${AWG_JMAX:-1000}
+AWG_S1=${AWG_S1:-86}
+AWG_S2=${AWG_S2:-574}
+AWG_H1=${AWG_H1:-991285757}
+AWG_H2=${AWG_H2:-1439803238}
+AWG_H3=${AWG_H3:-2097387803}
+AWG_H4=${AWG_H4:-863921769}
+SERVER_SUBNET=${SERVER_SUBNET:-}
+SERVER_INTERFACE=${SERVER_INTERFACE:-}
+
+log "=== AmneziaWG Native S2S Installation ==="
+log "Interface: $AWG_INTERFACE"
+log "Port: $AWG_PORT"
+log "VPN Network: $AWG_NET"
+log "Server IP: $AWG_SERVER_IP"
+if [ -n "$SERVER_SUBNET" ]; then
+    log "Server Subnet (S2S): $SERVER_SUBNET"
+fi
+
+# Check if amneziawg-go is installed
+check_amneziawg_installed() {
+    if command -v amneziawg-go &>/dev/null && command -v awg &>/dev/null; then
+        log "AmneziaWG tools already installed"
+        return 0
+    fi
+    return 1
+}
+
+# Install AmneziaWG from source
+install_amneziawg() {
+    log "Installing AmneziaWG tools..."
+    
+    # Check for Go
+    if ! command -v go &>/dev/null; then
+        log "Installing Go..."
+        apt-get update
+        apt-get install -y golang-go
+    fi
+    
+    # Check Go version
+    GO_VERSION=$(go version | grep -oP 'go\d+\.\d+' | head -1)
+    log "Go version: $GO_VERSION"
+    
+    # Install dependencies
+    log "Installing dependencies..."
+    apt-get update
+    apt-get install -y git make gcc qrencode iptables iproute2
+    
+    # Build amneziawg-go from submodule
+    if [ -d "$PROJECT_DIR/amneziawg-go" ]; then
+        log "Building amneziawg-go from submodule..."
+        cd "$PROJECT_DIR/amneziawg-go"
+        make
+        cp amneziawg-go /usr/local/bin/
+        chmod +x /usr/local/bin/amneziawg-go
+        log "amneziawg-go installed to /usr/local/bin/"
+    else
+        error "amneziawg-go submodule not found. Run 'git submodule update --init --recursive'"
+        exit 1
+    fi
+    
+    # Build amneziawg-tools from submodule
+    if [ -d "$PROJECT_DIR/amneziawg-tools" ]; then
+        log "Building amneziawg-tools from submodule..."
+        cd "$PROJECT_DIR/amneziawg-tools/src"
+        make
+        make install
+        log "awg tools installed"
+    else
+        error "amneziawg-tools submodule not found. Run 'git submodule update --init --recursive'"
+        exit 1
+    fi
+    
+    cd "$PROJECT_DIR"
+}
+
+# Generate server keys if not exist
+generate_keys() {
+    log "Checking server keys..."
+    
+    mkdir -p "$PROJECT_DIR/config"
+    chmod 750 "$PROJECT_DIR/config"
+    
+    if [ ! -f "$PROJECT_DIR/config/server_private.key" ]; then
+        log "Generating server private key..."
+        awg genkey > "$PROJECT_DIR/config/server_private.key"
+        chmod 600 "$PROJECT_DIR/config/server_private.key"
+    fi
+    
+    if [ ! -f "$PROJECT_DIR/config/server_public.key" ]; then
+        log "Generating server public key..."
+        awg pubkey < "$PROJECT_DIR/config/server_private.key" > "$PROJECT_DIR/config/server_public.key"
+    fi
+    
+    SERVER_PRIVATE_KEY=$(cat "$PROJECT_DIR/config/server_private.key" | tr -d '\n')
+    SERVER_PUBLIC_KEY=$(cat "$PROJECT_DIR/config/server_public.key" | tr -d '\n')
+    
+    log "Server keys ready"
+}
+
+# Get public IP
+get_public_ip() {
+    if [ "$SERVER_PUBLIC_IP" = "auto" ] || [ -z "$SERVER_PUBLIC_IP" ]; then
+        log "Detecting public IP..."
+        
+        # Try ip route first
+        local_ip=$(ip -4 route get 1.1.1.1 2>/dev/null | grep -oP 'src \K\S+' || true)
+        if [ -n "$local_ip" ] && ! echo "$local_ip" | grep -qE '^(10\.|172\.(1[6-9]|2[0-9]|3[01])\.|192\.168\.|127\.)'; then
+            SERVER_PUBLIC_IP="$local_ip"
+            log "Public IP detected via route: $SERVER_PUBLIC_IP"
+            return
+        fi
+        
+        # Try external services
+        for service in "http://eth0.me" "https://ipv4.icanhazip.com" "https://api.ipify.org"; do
+            ip=$(curl -4 -s --connect-timeout 5 "$service" 2>/dev/null | tr -d '[:space:]')
+            if echo "$ip" | grep -qE '^[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$'; then
+                SERVER_PUBLIC_IP="$ip"
+                log "Public IP detected via $service: $SERVER_PUBLIC_IP"
+                return
+            fi
+        done
+        
+        error "Could not detect public IP. Set SERVER_PUBLIC_IP in .env"
+        exit 1
+    else
+        log "Using configured public IP: $SERVER_PUBLIC_IP"
+    fi
+}
+
+# Create server configuration
+create_server_config() {
+    log "Creating server configuration..."
+    
+    CONFIG_FILE="$PROJECT_DIR/config/${AWG_INTERFACE}.conf"
+    
+    cat > "$CONFIG_FILE" << EOF
+[Interface]
+ListenPort = ${AWG_PORT}
+PrivateKey = ${SERVER_PRIVATE_KEY}
+
+# AmneziaWG obfuscation parameters
+Jc = ${AWG_JC}
+Jmin = ${AWG_JMIN}
+Jmax = ${AWG_JMAX}
+S1 = ${AWG_S1}
+S2 = ${AWG_S2}
+H1 = ${AWG_H1}
+H2 = ${AWG_H2}
+H3 = ${AWG_H3}
+H4 = ${AWG_H4}
+
+EOF
+    
+    # Add existing clients
+    if [ -d "$PROJECT_DIR/clients" ]; then
+        for client_file in "$PROJECT_DIR/clients"/*.conf; do
+            if [ -f "$client_file" ]; then
+                client_name=$(basename "$client_file" .conf)
+                public_key_file="$PROJECT_DIR/clients/${client_name}_public.key"
+                
+                if [ -f "$public_key_file" ]; then
+                    public_key=$(cat "$public_key_file")
+                    client_ip=$(grep "^Address" "$client_file" | cut -d'=' -f2 | tr -d ' ' | cut -d'/' -f1)
+                    
+                    cat >> "$CONFIG_FILE" << EOF
+
+[Peer]
+# ${client_name}
+PublicKey = ${public_key}
+AllowedIPs = ${client_ip}/32
+EOF
+                    log "Added client: $client_name ($client_ip)"
+                fi
+            fi
+        done
+    fi
+    
+    log "Server configuration created: $CONFIG_FILE"
+}
+
+# Create systemd service
+create_systemd_service() {
+    log "Creating systemd service..."
+    
+    # Determine output interface for NAT
+    OUT_INTERFACE="${SERVER_INTERFACE:-}"
+    if [ -z "$OUT_INTERFACE" ]; then
+        OUT_INTERFACE=$(ip route | grep default | awk '{print $5}' | head -1)
+        if [ -z "$OUT_INTERFACE" ]; then
+            OUT_INTERFACE="eth0"
+        fi
+    fi
+    
+    cat > /etc/systemd/system/amneziawg-s2s.service << EOF
+[Unit]
+Description=AmneziaWG S2S VPN Server
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+Environment=WG_PROCESS_FOREGROUND=1
+Environment=AWG_INTERFACE=${AWG_INTERFACE}
+Environment=AWG_PORT=${AWG_PORT}
+Environment=AWG_NET=${AWG_NET}
+Environment=AWG_SERVER_IP=${AWG_SERVER_IP}
+Environment=SERVER_SUBNET=${SERVER_SUBNET}
+Environment=OUT_INTERFACE=${OUT_INTERFACE}
+Environment=PROJECT_DIR=${PROJECT_DIR}
+
+ExecStartPre=/bin/bash -c 'echo 1 > /proc/sys/net/ipv4/ip_forward'
+ExecStartPre=/bin/bash -c 'echo 1 > /proc/sys/net/ipv4/conf/all/src_valid_mark'
+ExecStart=${PROJECT_DIR}/scripts/start-s2s.sh
+ExecStop=${PROJECT_DIR}/scripts/stop-s2s.sh
+
+Restart=always
+RestartSec=5
+
+[Install]
+WantedBy=multi-user.target
+EOF
+    
+    log "Systemd service created: /etc/systemd/system/amneziawg-s2s.service"
+    
+    # Reload systemd
+    systemctl daemon-reload
+    log "Systemd daemon reloaded"
+}
+
+# Enable IP forwarding permanently
+enable_ip_forwarding() {
+    log "Enabling IP forwarding..."
+    
+    # Enable now
+    echo 1 > /proc/sys/net/ipv4/ip_forward
+    echo 1 > /proc/sys/net/ipv4/conf/all/src_valid_mark
+    
+    # Make permanent
+    if ! grep -q "net.ipv4.ip_forward=1" /etc/sysctl.conf; then
+        echo "net.ipv4.ip_forward=1" >> /etc/sysctl.conf
+    fi
+    if ! grep -q "net.ipv4.conf.all.src_valid_mark=1" /etc/sysctl.conf; then
+        echo "net.ipv4.conf.all.src_valid_mark=1" >> /etc/sysctl.conf
+    fi
+    
+    sysctl -p >/dev/null 2>&1 || true
+    log "IP forwarding enabled"
+}
+
+# Main installation
+main() {
+    log "Starting native S2S installation..."
+    
+    # Check and install AmneziaWG
+    if ! check_amneziawg_installed; then
+        install_amneziawg
+    fi
+    
+    # Generate keys
+    generate_keys
+    
+    # Get public IP
+    get_public_ip
+    
+    # Create server config
+    create_server_config
+    
+    # Enable IP forwarding
+    enable_ip_forwarding
+    
+    # Create systemd service
+    create_systemd_service
+    
+    log ""
+    log "=== Installation Complete ==="
+    log ""
+    log "To start the S2S VPN server:"
+    log "  sudo systemctl start amneziawg-s2s"
+    log ""
+    log "To enable auto-start on boot:"
+    log "  sudo systemctl enable amneziawg-s2s"
+    log ""
+    log "To check status:"
+    log "  sudo systemctl status amneziawg-s2s"
+    log "  awg show ${AWG_INTERFACE}"
+    log ""
+    log "To add clients, use:"
+    log "  make client-add <name>"
+    log ""
+    if [ -n "$SERVER_SUBNET" ]; then
+        log "S2S Mode: Clients will have access to $SERVER_SUBNET"
+    fi
+}
+
+main "$@"

--- a/scripts/start-s2s.sh
+++ b/scripts/start-s2s.sh
@@ -1,0 +1,218 @@
+#!/bin/bash
+# Start script for AmneziaWG Native S2S Mode
+# Called by systemd service
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+
+# Get configuration from environment or defaults
+AWG_INTERFACE=${AWG_INTERFACE:-awg0}
+AWG_PORT=${AWG_PORT:-51820}
+AWG_NET=${AWG_NET:-10.13.13.0/24}
+AWG_SERVER_IP=${AWG_SERVER_IP:-10.13.13.1}
+SERVER_SUBNET=${SERVER_SUBNET:-}
+OUT_INTERFACE=${OUT_INTERFACE:-}
+
+# Get project directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="${PROJECT_DIR:-$(dirname "$SCRIPT_DIR")}"
+
+CONFIG_FILE="$PROJECT_DIR/config/${AWG_INTERFACE}.conf"
+
+log "=== Starting AmneziaWG S2S Server ==="
+log "Interface: $AWG_INTERFACE"
+log "Port: $AWG_PORT"
+log "VPN Network: $AWG_NET"
+log "Server IP: $AWG_SERVER_IP"
+if [ -n "$SERVER_SUBNET" ]; then
+    log "Server Subnet (S2S): $SERVER_SUBNET"
+fi
+
+# Determine output interface
+if [ -z "$OUT_INTERFACE" ]; then
+    OUT_INTERFACE=$(ip route | grep default | awk '{print $5}' | head -1)
+    if [ -z "$OUT_INTERFACE" ]; then
+        OUT_INTERFACE="eth0"
+    fi
+fi
+log "Output interface: $OUT_INTERFACE"
+
+# Check if interface already exists
+if ip link show ${AWG_INTERFACE} &>/dev/null; then
+    warn "Interface ${AWG_INTERFACE} already exists, removing..."
+    ip link del ${AWG_INTERFACE} 2>/dev/null || true
+fi
+
+# Clean up old socket
+rm -f /var/run/amneziawg/${AWG_INTERFACE}.sock 2>/dev/null || true
+
+# Check config file
+if [ ! -f "$CONFIG_FILE" ]; then
+    error "Config file not found: $CONFIG_FILE"
+    error "Run 'make install-s2s' first"
+    exit 1
+fi
+
+# Setup iptables rules
+setup_iptables() {
+    log "Setting up iptables rules..."
+    
+    # NAT for VPN clients to access internet
+    if ! iptables -t nat -C POSTROUTING -s ${AWG_NET} -o $OUT_INTERFACE -j MASQUERADE 2>/dev/null; then
+        iptables -t nat -A POSTROUTING -s ${AWG_NET} -o $OUT_INTERFACE -j MASQUERADE
+        log "NAT rule added (VPN -> internet)"
+    fi
+    
+    # Site-to-site: NAT for VPN clients to access local network
+    if [ -n "$SERVER_SUBNET" ]; then
+        if ! iptables -t nat -C POSTROUTING -s ${AWG_NET} -d ${SERVER_SUBNET} -j MASQUERADE 2>/dev/null; then
+            iptables -t nat -A POSTROUTING -s ${AWG_NET} -d ${SERVER_SUBNET} -j MASQUERADE
+            log "NAT rule added (VPN -> local network $SERVER_SUBNET)"
+        fi
+        
+        # Forward rules for S2S traffic
+        if ! iptables -C FORWARD -s ${AWG_NET} -d ${SERVER_SUBNET} -j ACCEPT 2>/dev/null; then
+            iptables -A FORWARD -s ${AWG_NET} -d ${SERVER_SUBNET} -j ACCEPT
+            log "FORWARD rule added (VPN -> local network)"
+        fi
+        
+        if ! iptables -C FORWARD -s ${SERVER_SUBNET} -d ${AWG_NET} -j ACCEPT 2>/dev/null; then
+            iptables -A FORWARD -s ${SERVER_SUBNET} -d ${AWG_NET} -j ACCEPT
+            log "FORWARD rule added (local network -> VPN)"
+        fi
+    fi
+    
+    # Forward rules for VPN interface
+    if ! iptables -C FORWARD -i ${AWG_INTERFACE} -j ACCEPT 2>/dev/null; then
+        iptables -A FORWARD -i ${AWG_INTERFACE} -j ACCEPT
+        log "FORWARD rule added (incoming)"
+    fi
+    
+    if ! iptables -C FORWARD -o ${AWG_INTERFACE} -j ACCEPT 2>/dev/null; then
+        iptables -A FORWARD -o ${AWG_INTERFACE} -j ACCEPT
+        log "FORWARD rule added (outgoing)"
+    fi
+    
+    # MSS clamping to prevent PMTUD Black Hole
+    if ! iptables -t mangle -C FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu 2>/dev/null; then
+        iptables -t mangle -A FORWARD -p tcp --tcp-flags SYN,RST SYN -j TCPMSS --clamp-mss-to-pmtu
+        log "MSS clamping rule added"
+    fi
+    
+    log "iptables setup complete"
+}
+
+# Start amneziawg-go
+start_interface() {
+    log "Starting amneziawg-go for interface ${AWG_INTERFACE}..."
+    
+    # Start amneziawg-go in background
+    export WG_PROCESS_FOREGROUND=1
+    amneziawg-go ${AWG_INTERFACE} &
+    AWG_PID=$!
+    
+    # Save PID
+    mkdir -p /var/run/amneziawg
+    echo $AWG_PID > /var/run/amneziawg/${AWG_INTERFACE}.pid
+    
+    # Wait for interface to be created
+    sleep 3
+    
+    # Check if process is running and interface exists
+    if ! kill -0 $AWG_PID 2>/dev/null; then
+        error "amneziawg-go process failed to start"
+        exit 1
+    fi
+    
+    if ! ip link show ${AWG_INTERFACE} &>/dev/null; then
+        error "Interface ${AWG_INTERFACE} was not created"
+        exit 1
+    fi
+    
+    log "amneziawg-go started (PID: $AWG_PID)"
+    
+    # Configure interface
+    log "Configuring interface..."
+    
+    # Apply configuration
+    awg setconf ${AWG_INTERFACE} ${CONFIG_FILE}
+    
+    # Bring up interface and assign IP
+    ip link set ${AWG_INTERFACE} up
+    ip addr add ${AWG_SERVER_IP}/${AWG_NET##*/} dev ${AWG_INTERFACE} 2>/dev/null || true
+    
+    # Set MTU to prevent fragmentation issues
+    ip link set ${AWG_INTERFACE} mtu 1280
+    
+    log "Interface ${AWG_INTERFACE} configured"
+}
+
+# Cleanup function
+cleanup() {
+    log "Received shutdown signal..."
+    
+    # Stop amneziawg-go
+    if [ -f /var/run/amneziawg/${AWG_INTERFACE}.pid ]; then
+        AWG_PID=$(cat /var/run/amneziawg/${AWG_INTERFACE}.pid)
+        if kill -0 $AWG_PID 2>/dev/null; then
+            log "Stopping amneziawg-go (PID: $AWG_PID)..."
+            kill $AWG_PID
+        fi
+        rm -f /var/run/amneziawg/${AWG_INTERFACE}.pid
+    fi
+    
+    # Remove socket
+    rm -f /var/run/amneziawg/${AWG_INTERFACE}.sock 2>/dev/null || true
+    
+    # Remove interface
+    if ip link show ${AWG_INTERFACE} &>/dev/null; then
+        log "Removing interface ${AWG_INTERFACE}..."
+        ip link del ${AWG_INTERFACE} 2>/dev/null || true
+    fi
+    
+    log "Cleanup complete"
+    exit 0
+}
+
+# Handle signals
+trap cleanup SIGTERM SIGINT
+
+# Main
+main() {
+    # Setup iptables
+    setup_iptables
+    
+    # Start interface
+    start_interface
+    
+    log "=== AmneziaWG S2S Server Started ==="
+    awg show ${AWG_INTERFACE} 2>/dev/null || true
+    
+    # Keep running and monitor
+    while true; do
+        sleep 30
+        
+        # Check if process is still running
+        if [ -f /var/run/amneziawg/${AWG_INTERFACE}.pid ]; then
+            AWG_PID=$(cat /var/run/amneziawg/${AWG_INTERFACE}.pid)
+            if ! kill -0 $AWG_PID 2>/dev/null; then
+                warn "amneziawg-go process died, restarting..."
+                start_interface
+            fi
+        else
+            warn "PID file not found, restarting..."
+            start_interface
+        fi
+    done
+}
+
+main "$@"

--- a/scripts/stop-s2s.sh
+++ b/scripts/stop-s2s.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Stop script for AmneziaWG Native S2S Mode
+# Called by systemd service on stop
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+
+# Get configuration from environment or defaults
+AWG_INTERFACE=${AWG_INTERFACE:-awg0}
+AWG_NET=${AWG_NET:-10.13.13.0/24}
+SERVER_SUBNET=${SERVER_SUBNET:-}
+OUT_INTERFACE=${OUT_INTERFACE:-}
+
+log "=== Stopping AmneziaWG S2S Server ==="
+
+# Determine output interface
+if [ -z "$OUT_INTERFACE" ]; then
+    OUT_INTERFACE=$(ip route | grep default | awk '{print $5}' | head -1)
+    if [ -z "$OUT_INTERFACE" ]; then
+        OUT_INTERFACE="eth0"
+    fi
+fi
+
+# Stop amneziawg-go process
+if [ -f /var/run/amneziawg/${AWG_INTERFACE}.pid ]; then
+    AWG_PID=$(cat /var/run/amneziawg/${AWG_INTERFACE}.pid)
+    if kill -0 $AWG_PID 2>/dev/null; then
+        log "Stopping amneziawg-go (PID: $AWG_PID)..."
+        kill $AWG_PID 2>/dev/null || true
+        sleep 2
+        # Force kill if still running
+        if kill -0 $AWG_PID 2>/dev/null; then
+            warn "Process still running, force killing..."
+            kill -9 $AWG_PID 2>/dev/null || true
+        fi
+    fi
+    rm -f /var/run/amneziawg/${AWG_INTERFACE}.pid
+    log "Process stopped"
+else
+    warn "PID file not found"
+fi
+
+# Remove socket
+rm -f /var/run/amneziawg/${AWG_INTERFACE}.sock 2>/dev/null || true
+
+# Remove interface
+if ip link show ${AWG_INTERFACE} &>/dev/null; then
+    log "Removing interface ${AWG_INTERFACE}..."
+    ip link del ${AWG_INTERFACE} 2>/dev/null || true
+    log "Interface removed"
+else
+    warn "Interface ${AWG_INTERFACE} not found"
+fi
+
+# Clean up iptables rules (optional - comment out if you want to keep rules)
+cleanup_iptables() {
+    log "Cleaning up iptables rules..."
+    
+    # Remove NAT rule
+    iptables -t nat -D POSTROUTING -s ${AWG_NET} -o $OUT_INTERFACE -j MASQUERADE 2>/dev/null || true
+    
+    # Remove S2S NAT rule
+    if [ -n "$SERVER_SUBNET" ]; then
+        iptables -t nat -D POSTROUTING -s ${AWG_NET} -d ${SERVER_SUBNET} -j MASQUERADE 2>/dev/null || true
+        iptables -D FORWARD -s ${AWG_NET} -d ${SERVER_SUBNET} -j ACCEPT 2>/dev/null || true
+        iptables -D FORWARD -s ${SERVER_SUBNET} -d ${AWG_NET} -j ACCEPT 2>/dev/null || true
+    fi
+    
+    # Remove forward rules
+    iptables -D FORWARD -i ${AWG_INTERFACE} -j ACCEPT 2>/dev/null || true
+    iptables -D FORWARD -o ${AWG_INTERFACE} -j ACCEPT 2>/dev/null || true
+    
+    # Note: We don't remove MSS clamping rule as it might be used by other services
+    
+    log "iptables cleanup complete"
+}
+
+# Uncomment to clean up iptables on stop
+# cleanup_iptables
+
+log "=== AmneziaWG S2S Server Stopped ==="
+exit 0

--- a/scripts/uninstall-s2s.sh
+++ b/scripts/uninstall-s2s.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# Uninstall script for AmneziaWG Native S2S Mode
+# Removes systemd service and cleans up
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${GREEN}[$(date '+%Y-%m-%d %H:%M:%S')]${NC} $1"; }
+warn() { echo -e "${YELLOW}[$(date '+%Y-%m-%d %H:%M:%S')] WARNING:${NC} $1"; }
+error() { echo -e "${RED}[$(date '+%Y-%m-%d %H:%M:%S')] ERROR:${NC} $1"; }
+
+# Check root
+if [ "$EUID" -ne 0 ]; then
+    error "This script must be run as root"
+    exit 1
+fi
+
+# Get script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load .env for configuration
+AWG_INTERFACE=${AWG_INTERFACE:-awg0}
+if [ -f "$PROJECT_DIR/.env" ]; then
+    set -a
+    source "$PROJECT_DIR/.env"
+    set +a
+fi
+
+log "=== Uninstalling AmneziaWG Native S2S ==="
+
+# Stop and disable systemd service
+if systemctl is-active --quiet amneziawg-s2s 2>/dev/null; then
+    log "Stopping amneziawg-s2s service..."
+    systemctl stop amneziawg-s2s
+fi
+
+if systemctl is-enabled --quiet amneziawg-s2s 2>/dev/null; then
+    log "Disabling amneziawg-s2s service..."
+    systemctl disable amneziawg-s2s
+fi
+
+# Remove systemd service file
+if [ -f /etc/systemd/system/amneziawg-s2s.service ]; then
+    log "Removing systemd service file..."
+    rm -f /etc/systemd/system/amneziawg-s2s.service
+    systemctl daemon-reload
+    log "Systemd service removed"
+else
+    warn "Systemd service file not found"
+fi
+
+# Stop any running amneziawg-go process
+if [ -f /var/run/amneziawg/${AWG_INTERFACE}.pid ]; then
+    AWG_PID=$(cat /var/run/amneziawg/${AWG_INTERFACE}.pid)
+    if kill -0 $AWG_PID 2>/dev/null; then
+        log "Stopping amneziawg-go process..."
+        kill $AWG_PID 2>/dev/null || true
+        sleep 2
+    fi
+    rm -f /var/run/amneziawg/${AWG_INTERFACE}.pid
+fi
+
+# Remove socket
+rm -f /var/run/amneziawg/${AWG_INTERFACE}.sock 2>/dev/null || true
+
+# Remove interface if exists
+if ip link show ${AWG_INTERFACE} &>/dev/null; then
+    log "Removing interface ${AWG_INTERFACE}..."
+    ip link del ${AWG_INTERFACE} 2>/dev/null || true
+fi
+
+# Clean up PID directory
+rmdir /var/run/amneziawg 2>/dev/null || true
+
+log ""
+log "=== Uninstallation Complete ==="
+log ""
+log "Note: The following were NOT removed:"
+log "  - AmneziaWG binaries (/usr/local/bin/amneziawg-go, awg)"
+log "  - Configuration files ($PROJECT_DIR/config/)"
+log "  - Client files ($PROJECT_DIR/clients/)"
+log "  - IP forwarding settings in /etc/sysctl.conf"
+log ""
+log "To remove binaries manually:"
+log "  rm -f /usr/local/bin/amneziawg-go"
+log "  rm -f /usr/local/bin/awg"
+log ""
+log "You can still use Docker mode with 'make up' or 'make up-s2s'"


### PR DESCRIPTION
# Add native S2S mode to avoid Docker iptables conflicts

## Summary

This PR adds a native (non-Docker) installation option for site-to-site VPN mode. The Docker-based S2S mode using `network_mode: host` was experiencing connection drops after ~10 pings due to Docker daemon periodically overwriting iptables rules. The native mode runs AmneziaWG directly on the host system via systemd, avoiding these conflicts.

**New scripts added:**
- `scripts/install-s2s.sh` - Installs AmneziaWG from submodules, creates systemd service
- `scripts/start-s2s.sh` - Starts the VPN server with iptables setup and process monitoring
- `scripts/stop-s2s.sh` - Stops the server and cleans up
- `scripts/uninstall-s2s.sh` - Removes systemd service and cleans up

**New Makefile targets:**
- `make install-s2s` / `make uninstall-s2s`
- `make start-s2s-native` / `make stop-s2s-native` / `make restart-s2s-native`
- `make status-s2s-native` / `make logs-s2s-native`
- `make enable-s2s-native` / `make disable-s2s-native`

Also updates README documentation and fixes obfuscation parameter ranges (H1-H4 should be 32-bit integers, not 1-4).

## Review & Testing Checklist for Human

- [ ] **Test the full installation flow on the target server**: Run `make init-s2s && make install-s2s && make start-s2s-native` and verify the VPN starts correctly
- [ ] **Verify connection stability**: Connect a client and ping for 2+ minutes to confirm the connection drops are resolved
- [ ] **Check systemd service**: Verify `systemctl status amneziawg-s2s` shows correct status and logs
- [ ] **Test auto-restart**: Kill the amneziawg-go process manually and verify the monitoring loop restarts it
- [ ] **Verify iptables rules**: Check `iptables -L -n` and `iptables -t nat -L -n` to ensure rules are correct and don't conflict with existing rules

**Recommended test plan:**
1. On a fresh server, run `make init-s2s` (enter your local subnet)
2. Run `make install-s2s` (this compiles AmneziaWG from source - may take a few minutes)
3. Run `make start-s2s-native`
4. Add a client: `make client-add testclient`
5. Connect from client and run continuous ping for 2+ minutes
6. Verify connection remains stable (unlike Docker S2S mode which dropped after ~10 pings)

### Notes

- The scripts were syntax-checked but not tested on actual hardware - real-world testing is essential
- The installation script assumes Ubuntu/Debian (uses apt-get) and requires Go to compile from source
- The Docker S2S mode (`make up-s2s`) is preserved as a fallback option
- The stop script has iptables cleanup commented out by default to avoid removing rules that might be needed

Link to Devin run: https://app.devin.ai/sessions/dab3c78c87594b0099a1f9a083ba0a99
Requested by: Sychin Andrey (@asychin)