### PR TITLE
Fix native S2S client commands: argument parsing and path detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ NC := \033[0m
 
 # Get positional arguments (for simplified syntax like: make client-add john 10.13.13.5)
 # Filter out known targets to get just the arguments
-CLIENT_TARGETS := client-add client-rm client-qr client-config
+CLIENT_TARGETS := client-add client-rm client-qr client-config client-add-native-s2s client-rm-native-s2s client-qr-native-s2s client-config-native-s2s
 ARGS := $(filter-out $(CLIENT_TARGETS),$(MAKECMDGOALS))
 ARG1 := $(word 1,$(ARGS))
 ARG2 := $(word 2,$(ARGS))


### PR DESCRIPTION
## Summary

Fixes two bugs in native S2S client management commands:

1. **Argument parsing**: `make client-add-native-s2s asychin-native` was failing because the native-s2s targets weren't included in `CLIENT_TARGETS`, causing the client name to be misinterpreted as an IP address.

2. **Server key not found**: The `manage-clients.sh` script was hardcoded to look for server keys at `/app/config/` (Docker path), but native S2S mode stores keys in the project's `config/` directory.

The fix adds automatic detection of Docker vs native mode by checking for `/.dockerenv`, and uses appropriate paths for each mode.

## Review & Testing Checklist for Human

- [ ] **Test native S2S client add on actual server**: Run `make client-add-native-s2s testclient` with native S2S service running - this is the exact scenario that was broken
- [ ] **Verify Docker mode still works**: Run `make client-add testclient` in Docker mode to ensure backward compatibility
- [ ] **Check .env loading**: Verify that sourcing `.env` in native mode doesn't cause unexpected variable overrides

**Recommended test plan:**
```bash
# On server with native S2S running:
make up-native-s2s
make client-add-native-s2s testuser
make client-qr-native-s2s testuser

# Verify Docker mode still works:
make down-native-s2s
make up
make client-add dockertest
```

### Notes

The `/.dockerenv` detection is a standard pattern for detecting Docker containers. The script now dynamically determines paths based on execution context.

Link to Devin run: https://app.devin.ai/sessions/dab3c78c87594b0099a1f9a083ba0a99
Requested by: Sychin Andrey (@asychin)