### PR TITLE
Rename native-s2s commands to s2s

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,30 +55,30 @@ VPN clients can access devices in the server's local network. Use this when you 
 Native S2S mode runs directly on the host (without Docker) for stable connections:
 
 ```bash
-make up-native-s2s   # Start server (auto-init and install if needed)
+make up-s2s   # Start server (auto-init and install if needed)
 ```
 
-That's it! The `up-native-s2s` command will automatically:
+That's it! The `up-s2s` command will automatically:
 1. Initialize configuration (prompts for local subnet)
 2. Compile and install AmneziaWG
 3. Start the systemd service
 
 Native S2S commands:
-- `make up-native-s2s` - Start native S2S server (auto-init/install)
-- `make down-native-s2s` - Stop native S2S server
-- `make restart-native-s2s` - Restart native S2S server
-- `make status-native-s2s` - Show native S2S status
-- `make logs-native-s2s` - View native S2S logs
-- `make enable-native-s2s` - Enable auto-start on boot
-- `make disable-native-s2s` - Disable auto-start
-- `make uninstall-native-s2s` - Uninstall native S2S mode
+- `make up-s2s` - Start native S2S server (auto-init/install)
+- `make down-s2s` - Stop native S2S server
+- `make restart-s2s` - Restart native S2S server
+- `make status-s2s` - Show native S2S status
+- `make logs-s2s` - View native S2S logs
+- `make enable-s2s` - Enable auto-start on boot
+- `make disable-s2s` - Disable auto-start
+- `make uninstall-s2s` - Uninstall native S2S mode
 
 Native S2S client management:
-- `make client-add-native-s2s john` - Add client
-- `make client-rm-native-s2s john` - Remove client
-- `make client-qr-native-s2s john` - Show QR code
-- `make client-config-native-s2s john` - Show config
-- `make client-list-native-s2s` - List all clients
+- `make client-add-s2s john` - Add client
+- `make client-rm-s2s john` - Remove client
+- `make client-qr-s2s john` - Show QR code
+- `make client-config-s2s john` - Show config
+- `make client-list-s2s` - List all clients
 
 **Configuration**
 


### PR DESCRIPTION
## Summary

Simplifies S2S command names by removing the `native` prefix. Since Docker S2S mode was removed in PR #16, the `native` prefix is no longer needed for disambiguation.

**Command mapping:**
| Old Command | New Command |
|-------------|-------------|
| `make up-native-s2s` | `make up-s2s` |
| `make down-native-s2s` | `make down-s2s` |
| `make client-add-native-s2s` | `make client-add-s2s` |
| etc. | etc. |

This is a pure renaming change with no logic modifications.

## Review & Testing Checklist for Human

- [ ] **Test `make up-s2s`** - Verify the renamed command starts the S2S server correctly
- [ ] **Test `make client-add-s2s testuser`** - Verify client management works with new command names

**Recommended test:**
```bash
make up-s2s
make client-add-s2s testuser
make client-qr-s2s testuser
```

### Notes

This is a **breaking change** for anyone using the old `native-s2s` commands from PR #16/#17, but those were just merged so impact should be minimal.

Link to Devin run: https://app.devin.ai/sessions/dab3c78c87594b0099a1f9a083ba0a99
Requested by: Sychin Andrey (@asychin)